### PR TITLE
Feature/double push delay fix

### DIFF
--- a/Flowter.podspec
+++ b/Flowter.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Flowter"
-  spec.version      = "0.2.6"
+  spec.version      = "0.2.7"
   spec.summary      = "A lightweight and customizable UIViewController flow cordinator"
   spec.description  = "A lightweight, swifty and customizable UIViewController flow cordinators"
 

--- a/Flowter/Source/EndFlowStep.swift
+++ b/Flowter/Source/EndFlowStep.swift
@@ -5,7 +5,7 @@
 //  Created by Paulo Cesar Saito on 13/08/18.
 //  Copyright 2018 Zazcar. All rights reserved.
 //
-import Foundation
+import UIKit
 
 public struct MakeEndStep<ContainerType: UIViewController> {
     public func makeEndFlow(with container: ContainerType) -> EndFlowStep<ContainerType> {

--- a/Flowter/Source/EndFlowStep.swift
+++ b/Flowter/Source/EndFlowStep.swift
@@ -8,26 +8,28 @@
 import Foundation
 
 public struct MakeEndStep<ContainerType: UIViewController> {
-    public func makeEndFlow() -> EndFlowStep<ContainerType> {
-        return EndFlowStep<ContainerType>()
+    public func makeEndFlow(with container: ContainerType) -> EndFlowStep<ContainerType> {
+        return EndFlowStep<ContainerType>(with: container)
     }
 }
 
-public class EndFlowStep<ContainerType>: FlowStepType {
+public class EndFlowStep<ContainerType>: BaseFlowStepType {
     internal var endFlowAction: ( () -> Void)?
     
-    internal var isLastStep: Bool = false
-    internal var nextStep: FlowStepType?
-    internal var container: ContainerType?
+    internal var nextStep: BaseFlowStepType?
+    internal let isLastStep: Bool = true
+    internal let container: ContainerType
+    
+    init(with container: ContainerType) {
+        self.container = container
+    }
         
     //private methods
     internal func present(_ updating: Bool = false) {}
-    internal func dismiss() {}
     
     internal func destroy() {
         endFlowAction = nil
         
-        container = nil
         nextStep = nil
     }
     

--- a/Flowter/Source/EndFlowStep.swift
+++ b/Flowter/Source/EndFlowStep.swift
@@ -20,7 +20,7 @@ public class EndFlowStep<ContainerType>: BaseFlowStepType {
     internal let isLastStep: Bool = true
     internal let container: ContainerType
     
-    init(with container: ContainerType) {
+    internal init(with container: ContainerType) {
         self.container = container
     }
         

--- a/Flowter/Source/FinishedFlowter.swift
+++ b/Flowter/Source/FinishedFlowter.swift
@@ -5,7 +5,7 @@
 //  Created by Paulo Cesar Saito on 18/05/18.
 //  Copyright 2018 Zazcar. All rights reserved.
 //
-import Foundation
+import UIKit
 
 public struct FinishedFlowter<ContainerType> where ContainerType: UIViewController {
     internal let flowter: Flowter<ContainerType>

--- a/Flowter/Source/FlowStep.swift
+++ b/Flowter/Source/FlowStep.swift
@@ -5,7 +5,7 @@
 //  Created by Paulo Cesar Saito on 17/05/18.
 //  Copyright 2018 Zazcar. All rights reserved.
 //
-import Foundation
+import UIKit
 
 public struct MakeStep<ControllerType: Flowtable, ContainerType: UIViewController> {
     let container: ContainerType

--- a/Flowter/Source/FlowStep.swift
+++ b/Flowter/Source/FlowStep.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 public struct MakeStep<ControllerType: Flowtable, ContainerType: UIViewController> {
+    let container: ContainerType
+    
     public func make(withFactoryClosure: @escaping () -> ControllerType) -> FlowStep<ControllerType,ContainerType> {
-        return FlowStep<ControllerType,ContainerType>(with: withFactoryClosure)
+        return FlowStep<ControllerType,ContainerType>(with: withFactoryClosure, on: container)
     }
 
     public func make(with controller: @autoclosure @escaping () -> ControllerType) -> FlowStep<ControllerType,ContainerType> {
@@ -27,16 +29,17 @@ public class FlowStep<ControllerType: Flowtable, ContainerType>: FlowStepType {
     internal var dismissAction: StepActionType?
     internal var endFlowAction: ( () -> Void)?
 
-    internal var isLastStep: Bool = false
-    internal var nextStep: FlowStepType?
-    internal var container: ContainerType?
+    internal var nextStep: BaseFlowStepType?
+    internal let isLastStep: Bool = false
+    internal let container: ContainerType
 
     lazy var viewController: ControllerType = { [unowned self] in
         self.viewControllerFactory()
     }()
 
-    public init(with factory: @escaping ViewControllerFactoryType) {
+    public init(with factory: @escaping ViewControllerFactoryType, on container: ContainerType) {
         self.viewControllerFactory = factory
+        self.container = container
     }
 
     public func setPresentAction(_ action: @escaping StepActionType) {
@@ -53,20 +56,16 @@ public class FlowStep<ControllerType: Flowtable, ContainerType>: FlowStepType {
 
     //private methods
     internal func present(_ updating: Bool = false) {
-        guard let containerController = container else { fatalError("Flow Step does not have a container") }
-
         viewController.flow = FlowStepInfo(flowStep: self)
         if updating {
             viewController.updateFlowStepViewController()
         }
 
-        presentAction?(viewController, containerController)
+        presentAction?(viewController, container)
     }
 
     internal func dismiss() {
-        guard let containerController = container else { fatalError("Flow Step does not have a container") }
-
-        dismissAction?(viewController, containerController)
+        dismissAction?(viewController, container)
     }
 
     internal func destroy() {
@@ -74,7 +73,6 @@ public class FlowStep<ControllerType: Flowtable, ContainerType>: FlowStepType {
         dismissAction = nil
         endFlowAction = nil
 
-        container = nil
         nextStep = nil
 
         if !isLastStep {

--- a/Flowter/Source/FlowStepInfo.swift
+++ b/Flowter/Source/FlowStepInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct FlowStepInfo {
-    internal var flowStep: FlowStepType
+    internal var flowStep: BaseFlowStepType
 
     public func next(updating: Bool = false) {
         guard let nextStep = flowStep.nextStep, !nextStep.isLastStep else {
@@ -20,7 +20,7 @@ public struct FlowStepInfo {
     }
 
     public func back() {
-        flowStep.dismiss()
+        (flowStep as? FlowStepType)?.dismiss()
     }
 
     public func endFlow() {

--- a/Flowter/Source/FlowStepType.swift
+++ b/Flowter/Source/FlowStepType.swift
@@ -7,13 +7,16 @@
 //
 import Foundation
 
-internal protocol FlowStepType {
+internal protocol BaseFlowStepType {
     var isLastStep: Bool { get }
-    var nextStep: FlowStepType? { get set }
+    var nextStep: BaseFlowStepType? { get set }
     var endFlowAction: ( () -> Void)? { get set }
     
     func present(_ updating: Bool)
-    func dismiss()
-    
+
     func destroy()
+}
+
+internal protocol FlowStepType: BaseFlowStepType {
+    func dismiss()
 }

--- a/Flowter/Source/Flowtable.swift
+++ b/Flowter/Source/Flowtable.swift
@@ -5,7 +5,7 @@
 //  Created by Paulo Cesar Saito on 17/05/18.
 //  Copyright 2018 Zazcar. All rights reserved.
 //
-import Foundation
+import UIKit
 
 //should call flowStep.next() or optionally flowStep.back() to continue the flow
 public protocol Flowtable where Self: UIViewController {

--- a/Flowter/Source/Flowter.swift
+++ b/Flowter/Source/Flowter.swift
@@ -109,6 +109,7 @@ extension Flowter {
     public static func defaultPresent() -> DefaultStepActionType {
         return { (vc, container) in
             if let navContainer = container as? UINavigationController {
+                guard navContainer.viewControllers.contains(vc) == false else { return }
                 let newViewControllers = navContainer.viewControllers + [vc]
                 navContainer.setViewControllers(newViewControllers, animated: true)
             } else {

--- a/Flowter/Source/Flowter.swift
+++ b/Flowter/Source/Flowter.swift
@@ -5,7 +5,7 @@
 //  Created by Paulo Cesar Saito on 17/05/18.
 //  Copyright 2018 Zazcar. All rights reserved.
 //
-import Foundation
+import UIKit
 
 public class Flowter<ContainerType> where ContainerType: UIViewController {
 

--- a/Flowter/Source/Flowter.swift
+++ b/Flowter/Source/Flowter.swift
@@ -13,7 +13,7 @@ public class Flowter<ContainerType> where ContainerType: UIViewController {
     public typealias DefaultStepActionType = ( (_ vc: UIViewController, _ container: ContainerType) -> Void)
     public typealias EndFlowStepActionType = (_ container: ContainerType) -> Void
 
-    internal var steps = [FlowStepType]()
+    internal var steps = [BaseFlowStepType]()
 
     private let presentAction:  DefaultStepActionType
     private let dismissAction:  DefaultStepActionType
@@ -31,8 +31,7 @@ public class Flowter<ContainerType> where ContainerType: UIViewController {
 
     @discardableResult
     public func addStep<ControllerType>(with: StepFactoryType<ControllerType>) -> Flowter<ContainerType> {
-        let step = with(MakeStep<ControllerType,ContainerType>())
-        step.container = flowContainer
+        let step = with(MakeStep<ControllerType,ContainerType>(container: flowContainer))
 
         var lastStep = steps.last
         lastStep?.nextStep = step
@@ -50,9 +49,7 @@ public class Flowter<ContainerType> where ContainerType: UIViewController {
     }
 
     public func addEndFlowStep(_ action: @escaping EndFlowStepActionType) -> FinishedFlowter<ContainerType> {
-        let endStep = MakeEndStep<ContainerType>().makeEndFlow()
-        endStep.container = flowContainer
-        endStep.isLastStep = true
+        let endStep = MakeEndStep<ContainerType>().makeEndFlow(with: flowContainer)
         
         var lastStep = steps.last
         lastStep?.nextStep = endStep


### PR DESCRIPTION
- Fix double push with delay crash
- Split FlowStepType to remove unused interface from EndFlowStep
- Make container not optional on all FlowStep types
- Fix UIKit imports
- Make EndFlowStep initializer explicitly internal